### PR TITLE
Add - initial anisotropy angle defined on particles rather than on phases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ deps/
 .DS_Store
 env.cmake
 visualtests-out
+build/
+*.out
+*.o

--- a/MDLIB/AnisotropyRoutines.c
+++ b/MDLIB/AnisotropyRoutines.c
@@ -750,7 +750,11 @@ void InitialiseDirectorVector (grid* mesh, markers* particles, params* model, ma
     if ( particles->phase[k] != -1 ) {
 
       // Set up director vector
-      angle             = materials->aniso_angle[particles->phase[k]];
+      if (model->particle_aniso_angle) {
+        angle           = particles->aniso_angle[k];
+      } else {
+        angle           = materials->aniso_angle[particles->phase[k]];
+      }
       particles->nx[k]  = cos(angle);
       particles->nz[k]  = sin(angle);
       norm              = sqrt(particles->nx[k]*particles->nx[k] + particles->nz[k]*particles->nz[k]);

--- a/MDLIB/AnisotropyRoutines.c
+++ b/MDLIB/AnisotropyRoutines.c
@@ -738,11 +738,12 @@ void NonNewtonianViscosityGridAniso( grid *mesh, mat_prop *materials, params *mo
 /*------------------------------------------------------ M-Doodz -----------------------------------------------------*/
 /*--------------------------------------------------------------------------------------------------------------------*/
 
-void InitialiseDirectorVector (grid* mesh, markers* particles, params* model, mat_prop* materials ) {
+void InitialiseDirectorVector (grid* mesh, markers* particles, params* model, mat_prop* materials, double scaling_L) {
 
   int    cent=1, vert=0, prop=1, interp=0;
   int k;
   double angle, norm;
+  const double Earth_radius = 6370e3/scaling_L;
 
 #pragma omp parallel for shared( particles ) private( angle, norm )
   for (k=0; k<particles->Nb_part; k++) {
@@ -754,6 +755,9 @@ void InitialiseDirectorVector (grid* mesh, markers* particles, params* model, ma
         angle           = particles->aniso_angle[k];
       } else {
         angle           = materials->aniso_angle[particles->phase[k]];
+      }
+      if (model->polar == 1 ) {
+        angle = angle - atan(particles->x[k] / (particles->z[k] ));
       }
       particles->nx[k]  = cos(angle);
       particles->nz[k]  = sin(angle);

--- a/MDLIB/InputOutput.c
+++ b/MDLIB/InputOutput.c
@@ -1159,6 +1159,7 @@ Input ReadInputFile( char *fileName ) {
     model.topografix      = ReadInt2( fin, "topografix",      0 );
     model.aniso           = ReadInt2( fin, "aniso",           0 ); // Turns on anisotropy
     // model.aniso_fstrain   = ReadInt2( fin, "aniso_fstrain",   0 ); // Make anisotropy factor dependent on finite strain aspect ratio
+    model.particle_aniso_angle = ReadInt2( fin, "particle_aniso_angle", 0 ); // Enables setting anisotropy angle per particles rather than phases
     model.compressible    = ReadInt2( fin, "compressible",    0 ); // Turns on compressibility
     model.GNUplot_residuals = ReadInt2( fin, "GNUplot_residuals",    0 ); // Activate GNU plot residuals visualisation
     model.shear_style     = ReadInt2( fin, "shear_style",     0 ); // 0: pure shear, 2: periodic simple shear

--- a/MDLIB/Main_DOODZ.c
+++ b/MDLIB/Main_DOODZ.c
@@ -295,7 +295,7 @@ void RunMDOODZ(char *inputFileName, MdoodzSetup *setup) {
         P2Mastah( &input.model, particles, particles.X,     &mesh, mesh.X0_s , mesh.BCg.type,  1, 0, interp, vert, input.model.itp_stencil);
 
         if (input.model.aniso == 1 ) {
-            InitialiseDirectorVector ( &mesh, &particles, &input.model, &input.materials );
+            InitialiseDirectorVector ( &mesh, &particles, &input.model, &input.materials, input.scaling.L);
             P2Mastah( &input.model, particles, NULL, &mesh, mesh.d1_n,    mesh.BCp.type, -1, 0, interp, cent, input.model.itp_stencil);
             P2Mastah( &input.model, particles, NULL, &mesh, mesh.d2_n,    mesh.BCp.type, -2, 0, interp, cent, input.model.itp_stencil);
             P2Mastah( &input.model, particles, NULL, &mesh, mesh.angle_n, mesh.BCp.type, -3, 0, interp, cent, input.model.itp_stencil);

--- a/MDLIB/MemoryAllocFree.c
+++ b/MDLIB/MemoryAllocFree.c
@@ -247,7 +247,9 @@ markers PartAlloc(ParticlesInput particlesInput, params *model) {
   if (model->aniso == 1) {
     particles.nx          = DoodzCalloc(particles.Nb_part_max, sizeof(DoodzFP));
     particles.nz          = DoodzCalloc(particles.Nb_part_max, sizeof(DoodzFP));
-    particles.aniso_angle = DoodzCalloc(particles.Nb_part_max, sizeof(DoodzFP));
+    if (model->particle_aniso_angle) {
+      particles.aniso_angle = DoodzCalloc(particles.Nb_part_max, sizeof(DoodzFP));
+    }
   }
   return particles;
 }
@@ -317,7 +319,9 @@ void PartFree( markers *particles, params* model ) {
     if (model->aniso == 1) {
         DoodzFree(particles->nx);
         DoodzFree(particles->nz);
-        DoodzFree(particles->aniso_angle);
+        if (model->particle_aniso_angle) {
+          DoodzFree(particles->aniso_angle);
+        }
     }
     
 //    DoodzFree(particles->ddivth);

--- a/MDLIB/MemoryAllocFree.c
+++ b/MDLIB/MemoryAllocFree.c
@@ -245,8 +245,9 @@ markers PartAlloc(ParticlesInput particlesInput, params *model) {
   }
 
   if (model->aniso == 1) {
-    particles.nx = DoodzCalloc(particles.Nb_part_max, sizeof(DoodzFP));
-    particles.nz = DoodzCalloc(particles.Nb_part_max, sizeof(DoodzFP));
+    particles.nx          = DoodzCalloc(particles.Nb_part_max, sizeof(DoodzFP));
+    particles.nz          = DoodzCalloc(particles.Nb_part_max, sizeof(DoodzFP));
+    particles.aniso_angle = DoodzCalloc(particles.Nb_part_max, sizeof(DoodzFP));
   }
   return particles;
 }
@@ -316,6 +317,7 @@ void PartFree( markers *particles, params* model ) {
     if (model->aniso == 1) {
         DoodzFree(particles->nx);
         DoodzFree(particles->nz);
+        DoodzFree(particles->aniso_angle);
     }
     
 //    DoodzFree(particles->ddivth);

--- a/MDLIB/include/mdoodz.h
+++ b/MDLIB/include/mdoodz.h
@@ -93,6 +93,7 @@ typedef struct {
   const char     *writerSubfolder;
   int      save_initial_markers, load_initial_markers;
   char    *initial_markers_file;
+  int     particle_aniso_angle;
 } params;
 
 // Stucture scale contains scaling parameters
@@ -160,7 +161,8 @@ typedef double (*SetDensity_f)(MdoodzInput *input, Coordinates coordinates, int 
 typedef double (*SetXComponent_f)(MdoodzInput *input, Coordinates coordinates, int phase);
 typedef double (*SetPressure_f)(MdoodzInput *input, Coordinates coordinates, int phase);
 typedef double (*SetNoise_f)(MdoodzInput *input, Coordinates coordinates, int phase);
-typedef void   (*SetDefGrad_f)(MdoodzInput *input, Coordinates coordinates, int phase, Tensor2D*);
+typedef double (*SetAnisoAngle_f)(MdoodzInput *input, Coordinates coordinates, int phase);
+typedef Tensor2D (*SetDefGrad_f)(MdoodzInput *input, Coordinates coordinates, int phase);
 
 typedef struct {
   SetHorizontalVelocity_f SetHorizontalVelocity;
@@ -175,6 +177,7 @@ typedef struct {
   SetDensity_f            SetDensity;
   SetXComponent_f         SetXComponent;
   SetDefGrad_f            SetDefGrad;
+  SetAnisoAngle_f         SetAnisoAngle;
 } SetParticles_ff;
 
 typedef enum {

--- a/MDLIB/mdoodz-private.h
+++ b/MDLIB/mdoodz-private.h
@@ -34,6 +34,7 @@ typedef struct {
   double *T0, *P0, *x0, *z0, *Tmax, *Pmax, *divth;
   double *dsxxd, *dszzd, *dsxz;
   double *noise, *rho;
+  double *aniso_angle;
 } markers;
 
 

--- a/MDLIB/mdoodz-private.h
+++ b/MDLIB/mdoodz-private.h
@@ -519,7 +519,7 @@ void            RogerGuntherII(markers *, params, grid, int, scale);
 void            AccumulatedStrainII(grid *, scale, params, markers *, double *, double *, int, int, char *);
 void            AdvectFreeSurf(markers *, params, scale);
 
-void            InitialiseDirectorVector(grid *, markers *, params *, mat_prop *);
+void            InitialiseDirectorVector(grid *, markers *, params *, mat_prop *, double);
 void            NormalizeDirector(grid *, DoodzFP *, DoodzFP *, DoodzFP *, DoodzFP *, params *);
 void            RotateDirectorVector(grid, markers *, params, scale *);
 void            UpdateParticlePressure(grid *, scale, params, markers *, mat_prop *);

--- a/MDLIB/setup.c
+++ b/MDLIB/setup.c
@@ -113,10 +113,8 @@ void SetParticles(SetParticles_ff setParticles, MdoodzInput *instance, markers *
       particles->Fzx[np] = F.zx;
       particles->Fzz[np] = F.zz;
     }
-    if (setParticles.SetAnisoAngle) {
+    if (instance->model.particle_aniso_angle && setParticles.SetAnisoAngle) {
       particles->aniso_angle[np] = setParticles.SetAnisoAngle(instance, coordinates, particles->phase[np]) *M_PI / 180;
-    } else {
-      particles->aniso_angle[np] = 0.0;
     }
     ValidatePhase(particles->phase[np], instance->model.Nb_phases);
   }

--- a/MDLIB/setup.c
+++ b/MDLIB/setup.c
@@ -113,6 +113,11 @@ void SetParticles(SetParticles_ff setParticles, MdoodzInput *instance, markers *
       particles->Fzx[np] = F.zx;
       particles->Fzz[np] = F.zz;
     }
+    if (setParticles.SetAnisoAngle) {
+      particles->aniso_angle[np] = setParticles.SetAnisoAngle(instance, coordinates, particles->phase[np]);
+    } else {
+      particles->aniso_angle[np] = 0.0;
+    }
     ValidatePhase(particles->phase[np], instance->model.Nb_phases);
   }
 

--- a/MDLIB/setup.c
+++ b/MDLIB/setup.c
@@ -105,7 +105,7 @@ void SetParticles(SetParticles_ff setParticles, MdoodzInput *instance, markers *
     Tensor2D F;
     F.xx=1.; F.xz=0.; F.zx=0.; F.zz=1.; 
     if (setParticles.SetDefGrad) {
-      setParticles.SetDefGrad(instance, coordinates, particles->phase[np], &F);
+      F = setParticles.SetDefGrad(instance, coordinates, particles->phase[np]);
     }
     if (instance->model.fstrain==1) {
       particles->Fxx[np] = F.xx;

--- a/MDLIB/setup.c
+++ b/MDLIB/setup.c
@@ -114,7 +114,7 @@ void SetParticles(SetParticles_ff setParticles, MdoodzInput *instance, markers *
       particles->Fzz[np] = F.zz;
     }
     if (setParticles.SetAnisoAngle) {
-      particles->aniso_angle[np] = setParticles.SetAnisoAngle(instance, coordinates, particles->phase[np]);
+      particles->aniso_angle[np] = setParticles.SetAnisoAngle(instance, coordinates, particles->phase[np]) *M_PI / 180;
     } else {
       particles->aniso_angle[np] = 0.0;
     }

--- a/SETS/AnisoViscTest_evolv.c
+++ b/SETS/AnisoViscTest_evolv.c
@@ -1,4 +1,6 @@
 #include "mdoodz.h"
+#include "math.h"
+
 
 int SetPhase(MdoodzInput *input, Coordinates coordinates) {
   const double radius = input->model.user1 / input->scaling.L;
@@ -34,13 +36,31 @@ double SetAnisoAngle(MdoodzInput *input, Coordinates coordinates, int phase) {
   const double radius = input->model.user1 / input->scaling.L;
   if (coordinates.x * coordinates.x + coordinates.z * coordinates.z < radius * radius) {
     // nothing special in the inclusion
-    return 0.0;
+    return 135.0;
   }
   else {
-    // a bit more pure shear strain in the matrix
-    return 0.0;
+    // radial anisotropy in the matrix
+    if (coordinates.x >= 0) {
+      if (coordinates.z >= 0) {
+        // x>0, y>0
+        return atan(coordinates.z/coordinates.x) * 180.0 / M_PI;
+        } else {
+          // x>0, y<0
+          return 270.0 + atan(coordinates.x/-coordinates.z) * 180.0 / M_PI;
+        }
+      }
+      else {
+            if (coordinates.z >= 0) {
+              // x<0, y>0
+              return 90.0 + atan(-coordinates.x/coordinates.z) * 180.0 / M_PI;
+      } else {
+        // x<0, y<0
+        return 180.0 + atan(coordinates.z/coordinates.x) * 180.0 / M_PI;        
+      }
+    }
   }
 }
+  
 
 int main() {
   MdoodzSetup setup = {
@@ -48,7 +68,7 @@ int main() {
                    .SetPhase              = SetPhase,
                    .SetDensity            = SetDensity,
                    .SetDefGrad            = SetDefGrad,
-                   //.SetAnisoAngle         = SetAnisoAngle,
+                   .SetAnisoAngle         = SetAnisoAngle,
           },
           .SetBCs = &(SetBCs_ff){
                   .SetBCVx = SetPureOrSimpleShearBCVx,

--- a/SETS/AnisoViscTest_evolv.c
+++ b/SETS/AnisoViscTest_evolv.c
@@ -18,15 +18,27 @@ double SetDensity(MdoodzInput *input, Coordinates coordinates, int phase) {
   }
 }
 
-void SetDefGrad(MdoodzInput *input, Coordinates coordinates, int phase, Tensor2D* F) {
+Tensor2D SetDefGrad(MdoodzInput *input, Coordinates coordinates, int phase) {
   const double radius = input->model.user1 / input->scaling.L;
-  F->xx=1.; F->xz=0.; F->zx=0.; F->zz=1.;
   if (coordinates.x * coordinates.x + coordinates.z * coordinates.z < radius * radius) {
     // nothing special in the inclusion
+    return (Tensor2D) {.xx = 1., .xz = 0., .zx = 0., .zz = 1.,}; // initializes Fxx, Fxz, Fzx, Fzz 
   }
   else {
     // a bit more pure shear strain in the matrix
-    F->xx=1.1; F->xz=0.; F->zx=0.; F->zz=0.9;
+    return (Tensor2D) {.xx = 1.1, .xz = 0., .zx = 0., .zz = 0.9,}; // initializes Fxx, Fxz, Fzx, Fzz 
+  }
+}
+
+double SetAnisoAngle(MdoodzInput *input, Coordinates coordinates, int phase) {
+  const double radius = input->model.user1 / input->scaling.L;
+  if (coordinates.x * coordinates.x + coordinates.z * coordinates.z < radius * radius) {
+    // nothing special in the inclusion
+    return 90.0;
+  }
+  else {
+    // a bit more pure shear strain in the matrix
+    return 135.0;
   }
 }
 
@@ -36,6 +48,7 @@ int main() {
                    .SetPhase              = SetPhase,
                    .SetDensity            = SetDensity,
                    .SetDefGrad            = SetDefGrad,
+                   .SetAnisoAngle         = SetAnisoAngle,
           },
           .SetBCs = &(SetBCs_ff){
                   .SetBCVx = SetPureOrSimpleShearBCVx,

--- a/SETS/AnisoViscTest_evolv.c
+++ b/SETS/AnisoViscTest_evolv.c
@@ -34,11 +34,11 @@ double SetAnisoAngle(MdoodzInput *input, Coordinates coordinates, int phase) {
   const double radius = input->model.user1 / input->scaling.L;
   if (coordinates.x * coordinates.x + coordinates.z * coordinates.z < radius * radius) {
     // nothing special in the inclusion
-    return 90.0;
+    return 0.0;
   }
   else {
     // a bit more pure shear strain in the matrix
-    return 135.0;
+    return 0.0;
   }
 }
 
@@ -48,7 +48,7 @@ int main() {
                    .SetPhase              = SetPhase,
                    .SetDensity            = SetDensity,
                    .SetDefGrad            = SetDefGrad,
-                   .SetAnisoAngle         = SetAnisoAngle,
+                   //.SetAnisoAngle         = SetAnisoAngle,
           },
           .SetBCs = &(SetBCs_ff){
                   .SetBCVx = SetPureOrSimpleShearBCVx,

--- a/SETS/AnisoViscTest_evolv.txt
+++ b/SETS/AnisoViscTest_evolv.txt
@@ -17,6 +17,7 @@ free_surf_stab    = 0
 fstrain           = 1
 advection         = 1
 aniso             = 1
+particle_aniso_angle = 1
 
 /**** SCALES ****/
 eta = 1
@@ -25,8 +26,8 @@ V   = 1
 T   = 1
 
 /**** SPACE ****/
-Nx      = 51
-Nz      = 51
+Nx      = 151
+Nz      = 151
 Nt      = 50
 xmin    = -5.000000e-1
 zmin    = -5.000000e-1
@@ -107,7 +108,7 @@ gsel = 0             / grain size evo.
 eta0 = 1e0
 npwl = 0.0
 Qpwl = 0
-aniso_angle  = 135.0
+aniso_angle  = 120.0
 ani_fstrain  = 1     / activates finite strain anisotropy
 ani_fac_v    = 1.0
 
@@ -133,5 +134,5 @@ gsel = 0             / grain size evo.
 eta0 = 1e-1
 npwl = 0
 Qpwl = 0
-aniso_angle  = 135.0
+aniso_angle  = 120.0
 ani_fac_v    = 1.0

--- a/SETS/AnisoViscTest_evolv.txt
+++ b/SETS/AnisoViscTest_evolv.txt
@@ -17,7 +17,7 @@ free_surf_stab    = 0
 fstrain           = 1
 advection         = 1
 aniso             = 1
-particle_aniso_angle = 0
+particle_aniso_angle = 1
 
 /**** SCALES ****/
 eta = 1
@@ -108,7 +108,6 @@ gsel = 0             / grain size evo.
 eta0 = 1e0
 npwl = 0.0
 Qpwl = 0
-aniso_angle  = 60.0
 ani_fstrain  = 1     / activates finite strain anisotropy
 ani_fac_v    = 1.0
 
@@ -134,5 +133,4 @@ gsel = 0             / grain size evo.
 eta0 = 1e-1
 npwl = 0
 Qpwl = 0
-aniso_angle  = 45.0
 ani_fac_v    = 1.0

--- a/SETS/AnisoViscTest_evolv.txt
+++ b/SETS/AnisoViscTest_evolv.txt
@@ -17,7 +17,7 @@ free_surf_stab    = 0
 fstrain           = 1
 advection         = 1
 aniso             = 1
-particle_aniso_angle = 1
+particle_aniso_angle = 0
 
 /**** SCALES ****/
 eta = 1
@@ -108,7 +108,7 @@ gsel = 0             / grain size evo.
 eta0 = 1e0
 npwl = 0.0
 Qpwl = 0
-aniso_angle  = 120.0
+aniso_angle  = 60.0
 ani_fstrain  = 1     / activates finite strain anisotropy
 ani_fac_v    = 1.0
 
@@ -134,5 +134,5 @@ gsel = 0             / grain size evo.
 eta0 = 1e-1
 npwl = 0
 Qpwl = 0
-aniso_angle  = 120.0
+aniso_angle  = 45.0
 ani_fac_v    = 1.0


### PR DESCRIPTION
The initial anisotropy angle can now be defined directly on individual particles and does not need to be the same within each phase anymore.

<img src="https://user-images.githubusercontent.com/70947159/221697442-27bc7125-57b7-4bbd-8abb-60fb92501ac0.png" width="400" height="400" />
...for example an initially radial anisotropy within the matrix phase of an inclusion-matrix setup.