### PR TITLE
Rescale eta0 in homemade powerlaw rheology (fixes tduretz/MDOODZ7.0#124)

### DIFF
--- a/MDLIB/FlowLaws.c
+++ b/MDLIB/FlowLaws.c
@@ -61,7 +61,7 @@ void ReadDataPowerLaw( mat_prop* mat, params* model, int k, int number, scale* s
             mat->rpwl[k] = 0.0;
             mat->Qpwl[k] = mat->Qpwl[k];
             mat->Vpwl[k] = 0.0;
-            mat->Apwl[k] = pow(mat->eta0[k], -mat->npwl[k]);
+            mat->Apwl[k] = pow(mat->eta0[k]*scaling->eta, -mat->npwl[k]); // rescale eta0 here, as A will be scaled later on
             mat->fpwl[k] = 0.0;
             mat->apwl[k] = 0.0;
             success      = 1;

--- a/SETS/ViscousInclusionPWL.txt
+++ b/SETS/ViscousInclusionPWL.txt
@@ -1,0 +1,101 @@
+/**** RESTART ****/
+istep = 00001
+irestart = 0
+
+/**** OUTPUT FILES ****/
+writer          = 1
+writer_step     = 1
+writer_markers  = 0
+writer_debug    = 0
+writer_energies = 0
+
+/**** SCALES ****/
+eta = 10
+L   = 1
+V   = 1
+T   = 1
+
+/**** SPACE ****/
+Nx      = 101
+Nz      = 101
+Nt      = 1
+xmin    = -5.000000e-1
+zmin    = -5.000000e-1 
+xmax    =  5.000000e-1
+zmax    =  5.000000e-1
+
+/**** PARTICLES ****/
+Nx_part = 4
+Nz_part = 4
+
+/**** TIME ****/
+constant_dt = 1
+Courant     = 0.3
+dt          = 0.5
+RK          = 4
+
+/**** LINEAR SOLVER ****/
+noisy        = 0
+penalty      = 1e5
+lin_solver      = -1
+diag_scaling = 0
+lin_abs_div  = 1e-8
+lin_rel_div  = 1e-8
+
+/**** NON-LINEAR SOLVER ****/
+Newton      = 0 
+line_search = 0
+nit_max     = 100
+rel_tol_KSP = 1e-4
+nonlin_abs_mom   = 1e-8
+nonlin_abs_mom   = 1e-8
+nonlin_rel_div   = 1e-8
+nonlin_rel_div   = 1e-8
+
+/**** VISCOSITY CUT-OFF ****/
+min_eta      = 1e-3
+max_eta      = 1e6
+
+/**** SWITCHES ****/
+elastic         = 0
+free_surface         = 0
+free_surface_stab    = 0
+finite_strain           = 1
+advection         = 0
+gnuplot_log_res = 0
+eta_average           = 0
+
+/**** SETUP-DEPENDANT ****/
+shear_style     = 0
+periodic_x    = 0
+pure_shear_ALE = 1
+bkg_strain_rate           = 1
+user0           = 0  
+user1           = 0.15  / inclusion radius [m]
+user2           = 0
+user3           = 0
+
+/**** GRAVITY ****/
+gx = 0.0000
+gz = 0.000
+
+/**** MAT PROPERTIES ****/
+Nb_phases = 2
+
+/**** PHASE 1 ****/
+ID   = 0
+plast = 0
+cstv  = 0             / constant visc law
+pwlv = 1
+eta0  = 1000
+npwl  = 1.0
+Qpwl  = 0
+
+/**** PHASE 2 ****/
+ID   = 1
+plast = 0
+cstv  = 0             / constant visc law
+pwlv = 1
+eta0  = 1000
+npwl  = 1.0
+Qpwl  = 0


### PR DESCRIPTION
Because Apwl is scaled again in FlowLaws.c, one has to use the dimensional value of eta0 here.