### PR TITLE
Add makefile for Fuchs cluster

### DIFF
--- a/MDLIB/Makefiles/makefile_Fuchs
+++ b/MDLIB/Makefiles/makefile_Fuchs
@@ -1,4 +1,4 @@
-# MDOODZ 7.0 makefile
+# MDOODZ 7.0 makefile for Fuchs cluster
 SHELL := /bin/bash
 
 # Compiler

--- a/MDLIB/Makefiles/makefile_Fuchs
+++ b/MDLIB/Makefiles/makefile_Fuchs
@@ -1,0 +1,58 @@
+# MDOODZ 7.0 makefile
+SHELL := /bin/bash
+
+# Compiler
+CC = gcc
+
+# Path to setup file folder
+SET_PATH = ../SETS
+
+#---------------------------------------------------#
+# C flags
+CFLAGS = -std=c99 -D _UMFPACK_ -I ./include/ -I ./
+
+ifeq ($(OPT),yes)	
+	CFLAGS += -O3 -ftree-vectorize -funroll-loops -finline -fomit-frame-pointer -march=native
+else
+	CFLAGS += -g -Wall  -O0 -fno-inline -fno-omit-frame-pointer
+endif
+
+ifeq ($(OMP),yes)
+	CFLAGS += -fopenmp -D _OMP_
+else
+	CFLAGS += -Wno-unknown-pragmas 
+endif
+
+ifeq ($(VG),yes)
+	CFLAGS += -D _VG_ -Wno-format-zero-length
+endif
+
+ifeq ($(NEW_INPUT),yes)
+	CFLAGS += -D _NEW_INPUT_
+endif
+
+CFLAGS += -Wno-unused-variable  -Wno-comment
+#---------------------------------------------------#
+# Libraries
+LIBS = -lz -lhdf5 -lm
+
+# Related to SuiteSparse
+LIBS += -lcxsparse -lumfpack -lamd -lcholmod -lcolamd -lbtf -lsuitesparseconfig -L /home/amdjulia/duretz/spack/opt/spack/linux-almalinux9-ivybridge/gcc-11.4.1/openblas-0.3.28-2zqgpx6y7q4vts76q4zayebzkerym76w/lib/ -lopenblas
+
+# Link to openmp
+ifeq ($(OMP),yes)
+    LIBS += -lgomp
+endif
+
+#---------------------------------------------------#
+# Rules
+FILES = MeltingRoutines.o AnisotropyRoutines.o Main_DOODZ.o FD_Jacobian.o  RheologyParticles.o ChemicalRoutines.o ParticleReseeding.o Solvers.o StokesRoutines.o StokesAssemblyDecoupled.o AdvectionRoutines.o RheologyDensity.o HDF5Output.o SparseTools.o ThermalRoutines.o ThermalSolver.o ParticleRoutines.o FreeSurface.o FlowLaws.o MemoryAllocFree.o InputOutput.o MiscFunctions.o GridRoutines.o Setup.o $(SET_PATH)/$(SET).o 
+
+
+all: Doodzi_$(SET) 
+Doodzi_$(SET): ${FILES}
+	$(CC) ${FILES} -o $(SET) ${LIBS}
+
+clean:
+	cp $(SET_PATH)/$(SET).txt . 
+	rm -rf *o ./$(SET_PATH)/*.o $(SET) 


### PR DESCRIPTION
Finally, it worked. This makefile resolves conflicts in libraries being used by MDOODZ and SuiteSparse.

See description of the problem [there](https://github.com/DrTimothyAldenDavis/SuiteSparse/issues/879).