### PR TITLE
Fix flux balance and parameter consistency in AnneloreSubduction model

### DIFF
--- a/SETS/AnneloreSubduction.c
+++ b/SETS/AnneloreSubduction.c
@@ -4,6 +4,7 @@
 #include "stdlib.h"
 #include "stdio.h"
 
+
 int SetDualPhase(MdoodzInput *input, Coordinates coordinate, int phase) {
     
     // Passive tracer function. Useful for visualisation
@@ -11,20 +12,20 @@ int SetDualPhase(MdoodzInput *input, Coordinates coordinate, int phase) {
     double Lx = input->model.xmax - input->model.xmin;
     double Lz = input->model.zmax - input->model.zmin;
     double Ax, Az;
-    double f = 4.;
+    double f = 8.;
 
     // Set checkerboard for phase 0
-    Ax = cos( f*2.0*M_PI*coordinate.x / Lx  );
+    Ax = cos( 4*f*2.0*M_PI*coordinate.x / Lx  );
     Az = sin( f*2.0*M_PI*coordinate.z / Lz  );
     if ( ( (Az<0.0 && Ax<0.0) || (Az>0.0 && Ax>0.0) ) && dual_phase==0 && phase==0 ) {
         dual_phase = input->model.Nb_phases;
     }
 
-    // Set checkerboard for phase 1
+    // Set checkerboard for phase 2
     Az = sin( 3*f*2.0*M_PI*coordinate.z / Lz  );
-    Ax = cos( 3*f*2.0*M_PI*coordinate.x / Lx  );
+    Ax = cos( 4*3*f*2.0*M_PI*coordinate.x / Lx  );
     if ( ( (Az<0.0 && Ax<0.0) || (Az>0.0 && Ax>0.0) ) && dual_phase==1 && phase==1 ) {
-        dual_phase = input->model.Nb_phases;
+        dual_phase = input->model.Nb_phases+1;
     }
 
   return dual_phase;
@@ -98,7 +99,7 @@ char SetBCPType(MdoodzInput *instance, POSITION position) {
   }
 }
 
-SetBC SetBCT(MdoodzInput *instance, POSITION position, Coordinates coordinates,  double particleTemperature) {
+SetBC SetBCT(MdoodzInput *instance, POSITION position, double particleTemperature) {
   SetBC     bc;
   double surface_temperature = (0.0 + 273.15) / instance->scaling.T ;
   double mantle_temperature  = (instance->model.user0 + 273.15) / instance->scaling.T;
@@ -146,6 +147,7 @@ SetBC SetBCVx(MdoodzInput *instance, POSITION position, Coordinates coordinates)
   const double x = coordinates.x, z = coordinates.z;
 
   // Evaluate velocity of W and E boundaries
+  //  VxW =  -0.25*V_tot;
     VxW =  -0.5*V_tot;
     VxE =  0.5*V_tot;
 
@@ -193,7 +195,8 @@ SetBC SetBCVz(MdoodzInput *instance, POSITION position, Coordinates coordinates)
   const double prim_E_zmin = BoundaryVelocityProfilePrimitive(VxE, z_min, z_LAB, dz_smooth);
   const double intW = prim_W_zmax - prim_W_zmin;
   const double intE = prim_E_zmax - prim_E_zmin;
-  VzS = - ( fabs(intW) + fabs(intE) ) / Lx;
+  //hardcoded
+  VzS = -0.0791425;
 
   // Apply smooth transition with depth
   VzW = -BoundaryVelocityProfile(VzW, z, z_LAB, dz_smooth);

--- a/SETS/AnneloreSubduction.txt
+++ b/SETS/AnneloreSubduction.txt
@@ -7,6 +7,7 @@ istep    	= 500	/ Restart file number
 irestart 	= 1	/ Restart switch
 
 /**** OUTPUT FILES ****/
+writer_subfolder = AnneloreSubduction
 writer         	= 1	/ Write grid data switch
 writer_step    	= 25	/ Write interval 
 writer_markers 	= 0	/ Write marker data switch
@@ -41,7 +42,8 @@ pure_shear_ALE  	= 0  		/ 1: box stretched at constant strain rate; -1 box of co
 elastic            	= 1		/ Elastic rheology switch
 thermal            	= 1		/ Thermal solver switch
 free_surface       	= 1		/ Free evolution of topography switch
-free_surface_stab  	= 1		/ Free surface stabilization switch
+free_surface_stab  	= 0.5		/ Free surface stabilization switch
+topo_update             = 0
 
 initial_cooling    	= 1		/ Initial thermal equilibration switch
 subgrid_diffusion  	= 2		/ Subgrid diffusion algorithm switch
@@ -68,10 +70,10 @@ gz = -9.81				/ Gravitational acceleration in z
 /**** PHASE PROPERTIES ****/
 Nb_phases = 3 
 
-ID     = 0				/ Phase identity used to assign material to phase
-rho    = 3250.00 /asthenosphere		/ Reference density
-G      = 1e10				/ Shear modulus
-Cp     = 1050				/ Heat capacity
+ID     = 0	/mantle			/ Phase identity used to assign material to phase
+rho    = 3250.00         		/ Reference density
+G      = 3e10				/ Shear modulus
+Cv     = 1050				/ Heat capacity
 k      = 3.0				/ Thermal conductivity
 Qr     = 1e-10				/ Amount of radiogenic heat production
 C      = 1e6				/ Cohesion
@@ -87,16 +89,12 @@ gbsv   = 0				/ Choose grain boundary sliding parameters from database. Number c
 expv   = 40				/ Choose Peierls creep parameters from database. Number can be taken from Flow Laws.c
 gsel   = 0				/ Grain size evolution switch
 eta0   = 1e22				/ Constant viscosity value
-npwl   = 1				/ Custom power-law exponent
-Qpwl   = 0				/ Custom power-law activation energy
 gs_ref = 5e-3				/ Reference grain size
 
-ID     = 1
-rho    = 3250.00 /mantle 2
-G      = 1e10
-rho    = 3250.00 /lithosphere
-G      = 1e10
-Cp     = 1050
+ID     = 1   /lithopshere
+rho    = 3250.00
+G      = 3e10
+Cv     = 1050
 k      = 3.0
 Qr     = 1e-10
 C      = 1e7
@@ -112,15 +110,13 @@ gbsv   = 0
 expv   = 40
 gsel   = 0
 eta0   = 1e22
-npwl   = 2
-Qpwl   = 0
 gs_ref = 5e-3
 
-ID     = 2
-rho    = 3250.00 /wet mantle
-G      = 1e10
-Cp     = 1050
-k      = 3.0 / unrealistically high to mimic convecting mantle
+ID     = 2   /weak layer
+rho    = 3250.00 
+G      = 3e10
+Cv     = 1050
+k      = 3.0
 Qr     = 1e-10
 C      = 1e6
 phi    = 0
@@ -134,9 +130,7 @@ linv   = 40
 gbsv   = 0
 expv   = 40
 gsel   = 0
-eta0   = 5e20
-npwl   = 1
-Qpwl   = 0
+eta0   = 1e22
 gs_ref = 5e-3
 
 /**** DEFMAPS ****/
@@ -158,9 +152,11 @@ min_part_cell = 16	/ Minimum no. particles per cell
 
 /**** NON-LINEAR ITERATIONS ****/
 Newton           = 0		/ Newton iteration switch
-nit_max          = 5 		/ No. Nonlinear iterations. At least 5, for high resolution use from 10 to 20
+nit_max          = 15 		/ No. Nonlinear iterations. At least 5, for high resolution use from 10 to 20
 line_search      = 0		/ Activate line search algorithm
 nonlin_abs_mom   = 5.0e-8	/ Residual tolerances
 nonlin_abs_div   = 5.0e-8
 min_eta          = 5.0e18	/ Viscosity cutoffs for numerical stabilisation
 max_eta          = 1.0e25
+
+


### PR DESCRIPTION
Some preliminary commits to the AnneloreSubduction model

**Changes to AnneloreSubduction.txt**

shear modulus  changed from 1e10 => 3e10 to make it consistent with the values in paper

```
G      = 3e10
```


The following parameters were also changed during my experimentation with this model:

```
free_surface_stab  	= 0.5		/ Free surface stabilization switch


ID     = 2   /weak layer
...
eta0   = 1e22


nit_max          = 15  
```



I can't remember exactly why I changed free_surface_stab, or  eta0 in the weak layer, - they could probably be reverted so they remain consistent with what is currently in the Main branch. 

Note that this version is missing some interim updates associated with the "add melting" commit, e.g. 

```
Cv     = 1050
Cp     = 1050
```



**Changes to AnneloreSubduction.c**

I discovered that the function (SetBC SetBCVz) that balances the outflux (for a given convergence velocity) was not working properly - the model lost volume over time!. As interim step I hardcoded a correct basal flux term, which is accurate only for the default convergence velocity. This provides a temporary workaround but needs a proper fix. 

This change appears in the following lines:

```
  //hardcoded
  VzS = -0.0791425;
```
